### PR TITLE
fix: update to minimum required threads for nano config, 8 to 16

### DIFF
--- a/conf/druid/single-server/nano-quickstart/router/runtime.properties
+++ b/conf/druid/single-server/nano-quickstart/router/runtime.properties
@@ -20,15 +20,15 @@
 druid.service=druid/router
 druid.plaintextPort=8888
 
-druid.global.http.numMaxThreads=8
+druid.global.http.numMaxThreads=16
 
 # Broker
-druid.broker.http.numMaxThreads=8
+druid.broker.http.numMaxThreads=16
 
 # HTTP proxy
 druid.router.http.numConnections=25
 druid.router.http.readTimeout=PT5M
-druid.router.http.numMaxThreads=8
+druid.router.http.numMaxThreads=16
 druid.server.http.numThreads=4
 
 # Indexer


### PR DESCRIPTION
Rune CI can now run its tests