### PR TITLE
fix: update to minimum required threads for nano config, 16 to 64

### DIFF
--- a/conf/druid/single-server/nano-quickstart/router/runtime.properties
+++ b/conf/druid/single-server/nano-quickstart/router/runtime.properties
@@ -20,15 +20,15 @@
 druid.service=druid/router
 druid.plaintextPort=8888
 
-druid.global.http.numMaxThreads=16
+druid.global.http.numMaxThreads=64
 
 # Broker
-druid.broker.http.numMaxThreads=16
+druid.broker.http.numMaxThreads=64
 
 # HTTP proxy
 druid.router.http.numConnections=25
 druid.router.http.readTimeout=PT5M
-druid.router.http.numMaxThreads=16
+druid.router.http.numMaxThreads=64
 druid.server.http.numThreads=4
 
 # Indexer


### PR DESCRIPTION
javax.servlet.ServletException: java.lang.IllegalStateException: Insufficient configured threads: required=64 < max=16 for QueuedThreadPool. Changed accordingly